### PR TITLE
wordpressをk8sで構築する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+minikube-darwin-arm64

--- a/wordpress-kubernets/mysql-deployment.yaml
+++ b/wordpress-kubernets/mysql-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - name: mysql
+        image: mysql/mysql-server:latest
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: somewordpress
+        - name: MYSQL_DATABASE
+          value: wordpress
+        - name: MYSQL_USER
+          value: wordpress
+        - name: MYSQL_PASSWORD
+          value: wordpress
+        volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: mysql-storage
+      volumes:
+      - name: mysql-storage
+        persistentVolumeClaim:
+          claimName: mysql-pvc
+

--- a/wordpress-kubernets/mysql-pvc.yaml
+++ b/wordpress-kubernets/mysql-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+

--- a/wordpress-kubernets/mysql-service.yaml
+++ b/wordpress-kubernets/mysql-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+spec:
+  selector:
+    app: mysql
+  ports:
+  - port: 3306
+    targetPort: 3306
+

--- a/wordpress-kubernets/wordpress-deployment.yaml
+++ b/wordpress-kubernets/wordpress-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wordpress
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wordpress
+  template:
+    metadata:
+      labels:
+        app: wordpress
+    spec:
+      containers:
+      - name: wordpress
+        image: wordpress:latest
+        ports:
+        - containerPort: 80
+        env:
+        - name: WORDPRESS_DB_HOST
+          value: mysql-service:3306
+        - name: WORDPRESS_DB_USER
+          value: wordpress
+        - name: WORDPRESS_DB_PASSWORD
+          value: wordpress
+

--- a/wordpress-kubernets/wordpress-service.yaml
+++ b/wordpress-kubernets/wordpress-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wordpress-service
+spec:
+  type: NodePort
+  selector:
+    app: wordpress
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30080  
+


### PR DESCRIPTION
## なぜやるか
kubernetsの環境構築の練習
## なにをやったのか
wordpress-kubernetsフォルダに
wordpress-kubernets
├── mysql-deployment.yaml
├── mysql-pvc.yaml
├── mysql-service.yaml
├── wordpress-deployment.yaml
└── wordpress-service.yaml

このようなファイルを追加し、それぞれに必要なことを書いた
## 動作確認の手順
```
minikube service wordpress-service
```
このコマンドを打ってブラウザで確認